### PR TITLE
add block number to soundxyz

### DIFF
--- a/src/lifecycle.mjs
+++ b/src/lifecycle.mjs
@@ -140,14 +140,14 @@ export async function init(worker) {
     const strategy = finder(lifeCycleType, message.name);
     const messages = await run(strategy, lifeCycleType, "init", message.args);
     messages.worker.forEach((message) => worker.postMessage(message));
-    messages.lifecycle.forEach((message) => lch.emit("message", [message]));
+    messages.lifecycle.forEach((message) => lch.emit("message", message));
   });
 
   lch.emit("message", {
     type: "extraction",
     version: "0.0.1",
     name: "web3subgraph",
-    args: null,
+    args: [null],
   });
   //lch.emit("message", {
   //  type: "transformation",

--- a/src/strategies/soundxyz/extractor.mjs
+++ b/src/strategies/soundxyz/extractor.mjs
@@ -20,7 +20,7 @@ export const props = {
   },
 };
 
-export function init(tokenId) {
+export function init(tokenId, blockNumber) {
   const data = encodeCallSignature(
     props.signatures.tokenURI,
     ["uint256"],
@@ -42,7 +42,7 @@ export function init(tokenId) {
             to: props.contract.address,
             data,
           },
-          "latest",
+          blockNumber,
         ],
         results: null,
         error: null,

--- a/src/strategies/web3subgraph/extractor.mjs
+++ b/src/strategies/web3subgraph/extractor.mjs
@@ -14,11 +14,7 @@ function generate(first, lastId) {
           query manyNFTs($lastId: String) {
             nfts(first: ${first}, where: { id_gt: $lastId }) {
               id
-            }
-            _meta {
-              block {
-                number
-              }
+              createdAtBlockNumber
             }
           }`,
         variables: { lastId },
@@ -50,7 +46,7 @@ export function update(message) {
   if (nfts.length) {
     const lastId = nfts[nfts.length - 1].id;
     messages = [generate(props.first, lastId)];
-    write = JSON.stringify(message.results.data);
+    write = JSON.stringify(nfts);
   } else {
     messages = [
       {

--- a/src/strategies/web3subgraph/extractor.mjs
+++ b/src/strategies/web3subgraph/extractor.mjs
@@ -15,6 +15,11 @@ function generate(first, lastId) {
             nfts(first: ${first}, where: { id_gt: $lastId }) {
               id
             }
+            _meta {
+              block {
+                number
+              }
+            }
           }`,
         variables: { lastId },
       }),
@@ -45,7 +50,7 @@ export function update(message) {
   if (nfts.length) {
     const lastId = nfts[nfts.length - 1].id;
     messages = [generate(props.first, lastId)];
-    write = JSON.stringify(nfts);
+    write = JSON.stringify(message.results.data);
   } else {
     messages = [
       {

--- a/src/strategies/web3subgraph/transformer.mjs
+++ b/src/strategies/web3subgraph/transformer.mjs
@@ -1,6 +1,7 @@
 // @format
 const version = "0.1.0";
 
+import { toHex } from "eth-fun";
 import { toJSON } from "../../disc.mjs";
 
 function generate(address, tokenId, blockNumber) {
@@ -9,7 +10,7 @@ function generate(address, tokenId, blockNumber) {
       type: "extraction",
       version: "0.0.1",
       name: "soundxyz",
-      args: [tokenId, `0x${blockNumber.toString(16)}`],
+      args: [tokenId, toHex(parseInt(blockNumber))],
     };
   }
 }
@@ -34,12 +35,12 @@ export function transform(line) {
     "^(?<address>0x[a-fA-F0-9]{40})\\/(?<tokenId>[0-9]*)$"
   );
   const nfts = toJSON(
-    data.nfts.map((entry) => entry.id),
+    data.map((entry) => entry.id),
     expr
   );
   const messages = nfts
-    .map(({ address, tokenId }) =>
-      generate(address, tokenId, data._meta.block.number)
+    .map(({ address, tokenId }, i) =>
+      generate(address, tokenId, data[i].createdAtBlockNumber)
     )
     .filter((message) => !!message);
   return {

--- a/src/strategies/web3subgraph/transformer.mjs
+++ b/src/strategies/web3subgraph/transformer.mjs
@@ -3,13 +3,13 @@ const version = "0.1.0";
 
 import { toJSON } from "../../disc.mjs";
 
-function generate(address, tokenId) {
+function generate(address, tokenId, blockNumber) {
   if (address === "0x01ab7d30525e4f3010af27a003180463a6c811a6") {
     return {
       type: "extraction",
       version: "0.0.1",
       name: "soundxyz",
-      args: [tokenId],
+      args: [tokenId, `0x${blockNumber.toString(16)}`],
     };
   }
 }
@@ -34,11 +34,13 @@ export function transform(line) {
     "^(?<address>0x[a-fA-F0-9]{40})\\/(?<tokenId>[0-9]*)$"
   );
   const nfts = toJSON(
-    data.map((entry) => entry.id),
+    data.nfts.map((entry) => entry.id),
     expr
   );
   const messages = nfts
-    .map(({ address, tokenId }) => generate(address, tokenId))
+    .map(({ address, tokenId }) =>
+      generate(address, tokenId, data._meta.block.number)
+    )
     .filter((message) => !!message);
   return {
     messages,

--- a/test/strategies/web3strategy/transformer_test.mjs
+++ b/test/strategies/web3strategy/transformer_test.mjs
@@ -4,7 +4,10 @@ import test from "ava";
 import { transform } from "../../../src/strategies/web3subgraph/transformer.mjs";
 
 const address = "0x01dbbb64e6f6185ac9923d47e1f9b20dabadd263";
-const payload = [{ id: `${address}/0` }, { id: `${address}/1` }];
+const payload = {
+  nfts: [{ id: `${address}/0` }, { id: `${address}/1` }],
+  _meta: { block: { number: 1 } },
+};
 const sPayload = JSON.stringify(payload);
 
 test("web3subgraph transformer", (t) => {

--- a/test/strategies/web3strategy/transformer_test.mjs
+++ b/test/strategies/web3strategy/transformer_test.mjs
@@ -4,14 +4,14 @@ import test from "ava";
 import { transform } from "../../../src/strategies/web3subgraph/transformer.mjs";
 
 const address = "0x01dbbb64e6f6185ac9923d47e1f9b20dabadd263";
-const payload = {
-  nfts: [{ id: `${address}/0` }, { id: `${address}/1` }],
-  _meta: { block: { number: 1 } },
-};
+const payload = [
+  { id: `${address}/0`, createdAtBlockNumber: "14323199" },
+  { id: `${address}/1`, createdAtBlockNumber: "14323200" },
+];
 const sPayload = JSON.stringify(payload);
 
 test("web3subgraph transformer", (t) => {
-  const { write } = transform(sPayload);
+  const { write, messages } = transform(sPayload);
   const result = JSON.parse(write);
   t.is(result.length, 2);
   t.is(result[0].address, address);


### PR DESCRIPTION
Fixes #48 

This PR adds a block number parameter to soundxyz. The block number is fetched from web3subgraph as mentioned at  https://github.com/neume-network/strategies/issues/48#issue-1246759885. 

After changes in the web3subgraph extraction [this](https://github.com/neume-network/strategies/blob/00ca252faa2b2ae0d79d9dcd2f55a5ac994fffd6/test/strategies/web3strategy/transformer_test.mjs#L7) is how the web3subgraph-extraction data looks when written to the disc. All the other files that are written to disc look the same.

There is also another related issue #32 but I couldn't understand what "cycling through block numbers" means.