### PR TITLE
fix bug where `0x` is returned for json rpc calls

### DIFF
--- a/src/strategies/catalog/extractor.mjs
+++ b/src/strategies/catalog/extractor.mjs
@@ -72,9 +72,7 @@ export function makeRequest(tokenId, blockNumber) {
         to: props.contract.address,
         data,
       },
-      // TODO: https://github.com/neume-network/strategies/issues/68
-      //toHex(blockNumber),
-      "latest",
+      toHex(parseInt(blockNumber)),
     ],
     results: null,
     error: null,

--- a/src/strategies/soundxyz/extractor.mjs
+++ b/src/strategies/soundxyz/extractor.mjs
@@ -72,9 +72,7 @@ export function makeRequest(tokenId, blockNumber) {
         to: props.contract.address,
         data,
       },
-      // TODO: https://github.com/neume-network/strategies/issues/68
-      //toHex(blockNumber),
-      "latest",
+      toHex(parseInt(blockNumber)),
     ],
     results: null,
     error: null,


### PR DESCRIPTION
Fixes #68 

Since this PR we are querying older blocks the cloudflare-eth does not work. We will need to use some other node in CI. However, I ran the tests locally and they work.