### PR TITLE
add test to match strategy name with its directory name

### DIFF
--- a/src/strategies/catalog-get-tokenuri/transformer.mjs
+++ b/src/strategies/catalog-get-tokenuri/transformer.mjs
@@ -1,7 +1,7 @@
 // @format
 import logger from "../../logger.mjs";
 
-export const name = "catalog";
+export const name = "catalog-get-tokenuri";
 const log = logger(name);
 export const version = "0.1.0";
 

--- a/src/strategies/catalog-get-tokenuri/transformer.mjs
+++ b/src/strategies/catalog-get-tokenuri/transformer.mjs
@@ -1,9 +1,9 @@
 // @format
 import logger from "../../logger.mjs";
 
-const name = "catalog";
+export const name = "catalog";
 const log = logger(name);
-const version = "0.1.0";
+export const version = "0.1.0";
 
 export function onClose() {
   log("closed");

--- a/src/strategies/soundxyz-get-tokenuri/transformer.mjs
+++ b/src/strategies/soundxyz-get-tokenuri/transformer.mjs
@@ -3,9 +3,9 @@ import { decodeCallOutput } from "eth-fun";
 
 import logger from "../../logger.mjs";
 
-const name = "soundxyz-get-tokenuri";
+export const name = "soundxyz-get-tokenuri";
 const log = logger(name);
-const version = "0.1.0";
+export const version = "0.1.0";
 
 export function onClose() {
   log("closed");

--- a/src/strategies/soundxyz-metadata/transformer.mjs
+++ b/src/strategies/soundxyz-metadata/transformer.mjs
@@ -3,9 +3,9 @@ import { decodeCallOutput } from "eth-fun";
 
 import logger from "../../logger.mjs";
 
-const name = "soundxyz-metadata";
+export const name = "soundxyz-metadata";
 const log = logger(name);
-const version = "0.1.0";
+export const version = "0.1.0";
 
 export function onClose() {
   log("closed");

--- a/src/strategies/soundxyz/transformer.mjs
+++ b/src/strategies/soundxyz/transformer.mjs
@@ -1,8 +1,8 @@
 // @format
 import { decodeSolidityHexStringFactory } from "../../strategy-factories/decode-solidity-hex-string-factory/transformer.mjs";
 
-const name = "soundxyz";
-const version = "0.1.0";
+export const name = "soundxyz";
+export const version = "0.1.0";
 const nextStrategyName = "soundxyz-get-tokenuri";
 const resultKey = "tokenURI";
 

--- a/src/strategies/web3subgraph/transformer.mjs
+++ b/src/strategies/web3subgraph/transformer.mjs
@@ -7,9 +7,9 @@ import { toHex } from "eth-fun";
 import { toJSON } from "../../disc.mjs";
 import logger from "../../logger.mjs";
 
-const name = "web3subgraph";
+export const name = "web3subgraph";
 const log = logger(name);
-const version = "0.1.0";
+export const version = "0.1.0";
 
 export function onLine(line) {
   // NOTE: Parse isn't enclosed in a try catch loop as we want to catch the

--- a/src/strategies/zora-call-tokenmetadatauri/transformer.mjs
+++ b/src/strategies/zora-call-tokenmetadatauri/transformer.mjs
@@ -1,8 +1,8 @@
 // @format
 import { decodeSolidityHexStringFactory } from "../../strategy-factories/decode-solidity-hex-string-factory/transformer.mjs";
 
-const name = "zora-call-tokenmetadatauri";
-const version = "0.1.0";
+export const name = "zora-call-tokenmetadatauri";
+export const version = "0.1.0";
 const nextStrategyName = "catalog-get-tokenuri";
 const resultKey = "tokenURI";
 

--- a/src/strategies/zora-call-tokenuri/transformer.mjs
+++ b/src/strategies/zora-call-tokenuri/transformer.mjs
@@ -1,8 +1,8 @@
 // @format
 import { decodeSolidityHexStringFactory } from "../../strategy-factories/decode-solidity-hex-string-factory/transformer.mjs";
 
-const name = "zora-call-tokenuri";
-const version = "0.1.0";
+export const name = "zora-call-tokenuri";
+export const version = "0.1.0";
 const nextStrategyName = "catalog-get-tokenuri";
 const resultKey = "tokenURI";
 

--- a/test/strategy_name_test.mjs
+++ b/test/strategy_name_test.mjs
@@ -2,8 +2,10 @@
 import test from "ava";
 import { readdir } from "fs/promises";
 
+const STRAGIES_PATH = "../src/strategies/";
+
 test("if strategy name is the same as directory name", async (t) => {
-  const source = new URL("../src/strategies", import.meta.url);
+  const source = new URL(STRAGIES_PATH, import.meta.url);
 
   const directories = (await readdir(source, { withFileTypes: true })).filter(
     (dirent) => dirent.isDirectory()

--- a/test/strategy_name_test.mjs
+++ b/test/strategy_name_test.mjs
@@ -1,0 +1,36 @@
+//@format
+import test from "ava";
+import { readdir } from "fs/promises";
+
+test("if strategy name is the same as directory name", async (t) => {
+  const source = new URL("../src/strategies", import.meta.url);
+
+  const directories = (await readdir(source, { withFileTypes: true })).filter(
+    (dirent) => dirent.isDirectory()
+  );
+
+  await Promise.all(
+    directories.map(async (dir) => {
+      const name = dir.name;
+      const extractorSource = new URL(
+        `../src/strategies/${name}/extractor.mjs`,
+        import.meta.url
+      );
+      const transformerSource = new URL(
+        `../src/strategies/${name}/transformer.mjs`,
+        import.meta.url
+      );
+
+      await Promise.all(
+        [extractorSource, transformerSource].map(async (source) => {
+          const strategy = await import(source);
+          // For better debugging abilities
+          if (!strategy.name) {
+            throw new Error(`Strategy ${name} exports no name`);
+          }
+          t.is(strategy.name, name);
+        })
+      );
+    })
+  );
+});


### PR DESCRIPTION
Fixes #109

Note: This PR assumes the path to strategies and only tests if `extractor` and `transformer` files export the correct name. I did not go with testing all files because in future a strategy may contain other secondary files.