### PR TITLE
serialize and store errors in flat files

### DIFF
--- a/src/strategies/soundxyz-metadata/extractor.mjs
+++ b/src/strategies/soundxyz-metadata/extractor.mjs
@@ -156,7 +156,7 @@ export function update(message) {
   } else {
     return {
       messages: [],
-      write: null,
+      error: new Error("Unknown response: invalid message.results.length"),
     };
   }
 }

--- a/src/strategies/web3subgraph/transformer.mjs
+++ b/src/strategies/web3subgraph/transformer.mjs
@@ -16,7 +16,10 @@ export function onLine(line) {
   // error when we're envoking `function onLine`.
   const data = JSON.parse(line);
   if (!data) {
-    throw new Error(`No data passed to "onLine" handler`);
+    return {
+      messages: [],
+      error: new Error(`No data passed to "onLine" handler`),
+    };
   }
   const expr = new RegExp(
     "^(?<address>0x[a-fA-F0-9]{40})\\/(?<tokenId>[0-9]*)$"

--- a/src/strategy-factories/decode-solidity-hex-string-factory/transformer.mjs
+++ b/src/strategy-factories/decode-solidity-hex-string-factory/transformer.mjs
@@ -46,7 +46,7 @@ export const decodeSolidityHexStringFactory = (props) => {
       log(err.toString());
       return {
         messages: [],
-        write: null,
+        error: err,
       };
     }
 
@@ -57,7 +57,7 @@ export const decodeSolidityHexStringFactory = (props) => {
       log(err.toString());
       return {
         messages: [],
-        write: null,
+        write: err,
       };
     }
     return {


### PR DESCRIPTION
Fixes #123 

This PR formats error returned from any strategy to string. Then writes that string to a file `${strategyName}-{"transformation"|"extractor"}-errors`.

**Valid error types:**
```
return {
  messages: [], // Same as before
  // Error: https://nodejs.org/api/errors.html#class-error
  error: Error | string | Object | Array<Error> | Array<Object>
}
```

**Why support [Error](https://nodejs.org/api/errors.html#class-error)?**
Error captures stack trace which can be useful in log files. 

Example:
```
return {
  error: new Error("Something is wrong")
}
```
Output in file:
```
Error: Something is wrong
    at Module.init (file:///Users/vaibhav/repos/il3ven/music-os/core/src/strategies/src/strategies/web3subgraph/extractor.mjs:37:12)
    at run (file:///Users/vaibhav/repos/il3ven/music-os/core/src/strategies/src/lifecycle.mjs:120:42)
    at LifeCycleHandler.<anonymous> (file:///Users/vaibhav/repos/il3ven/music-os/core/src/strategies/src/lifecycle.mjs:175:28)
    at LifeCycleHandler.emit (node:events:527:28)
    at init (file:///Users/vaibhav/repos/il3ven/music-os/core/src/strategies/src/lifecycle.mjs:180:7)
```

**TODO:**
- [ ] Add test cases

---

@TimDaub If this approach is okay I will start adding test cases?