### PR TITLE
Update transformer.mjs

### DIFF
--- a/src/strategies/soundxyz-get-tokenuri/transformer.mjs
+++ b/src/strategies/soundxyz-get-tokenuri/transformer.mjs
@@ -53,20 +53,17 @@ export function onLine(line) {
         {
           version,
           uri: datum.audio_url,
-          // TODO
-          //mimetype: "audio/mp3",
+          //mimetype: "audio",
         },
         {
           version,
           uri: datum.image,
-          // TODO
-          //mimetype: "image/jpeg",
+          //mimetype: "image",
         },
         {
           version,
           uri: datum.animation_url,
-          // TODO
-          //mimetype: "image/gif",
+          //mimetype: "image",
         },
       ],
     }),

--- a/src/strategies/soundxyz-get-tokenuri/transformer.mjs
+++ b/src/strategies/soundxyz-get-tokenuri/transformer.mjs
@@ -53,17 +53,17 @@ export function onLine(line) {
         {
           version,
           uri: datum.audio_url,
-          //mimetype: "audio",
+          mimetype: "audio",
         },
         {
           version,
           uri: datum.image,
-          //mimetype: "image",
+          mimetype: "image",
         },
         {
           version,
           uri: datum.animation_url,
-          //mimetype: "image",
+          mimetype: "image",
         },
       ],
     }),


### PR DESCRIPTION
Allow mimetype to be generic `image`, `video`, `audio` for now till we have a strategy pulling actual mimetype.