### PR TITLE
CLI: take crawl path as an input

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,6 +1,6 @@
 //@format
 import { init } from "./lifecycle.mjs";
 
-export async function run(worker) {
-  init(worker);
+export async function run(worker, crawlPath) {
+  init(worker, crawlPath);
 }

--- a/src/lifecycle.mjs
+++ b/src/lifecycle.mjs
@@ -177,7 +177,7 @@ export function extract(strategy, worker, messageRouter, args = []) {
   });
 }
 
-export async function init(worker) {
+export async function init(worker, crawlPath) {
   const finder = await setupFinder();
   const messageRouter = new EventEmitter();
 
@@ -188,71 +188,6 @@ export async function init(worker) {
 
     messageRouter.emit(`${message.commissioner}-extraction`, message);
   });
-
-  // crawlPath[i] and crawlPath[i+1] are executed in sequence
-  // crawlPath[i][j] and crawlPath[i][j+1] are executed in parallel
-  // TODO: Define and check for valid message schema. Current lifecycle message schema
-  // doesn't work. https://github.com/neume-network/message-schema/issues/19
-  const crawlPath = [
-    [{ name: "web3subgraph", extractor: {}, transform: {} }],
-    [
-      {
-        name: "soundxyz-call-tokenuri",
-        extractor: {
-          args: [resolve(env.DATA_DIR, "web3subgraph-transformation")],
-        },
-        transformer: {},
-      },
-      {
-        name: "zora-call-tokenuri",
-        extractor: {
-          args: [resolve(env.DATA_DIR, "web3subgraph-transformation")],
-        },
-        transformer: {},
-      },
-      {
-        name: "zora-call-tokenmetadatauri",
-        extractor: {
-          args: [resolve(env.DATA_DIR, "web3subgraph-transformation")],
-        },
-        transformer: {},
-      },
-      {
-        name: "soundxyz-metadata",
-        extractor: {
-          args: [resolve(env.DATA_DIR, "web3subgraph-transformation")],
-        },
-        transformer: {},
-      },
-    ],
-    [
-      {
-        name: "soundxyz-get-tokenuri",
-        extractor: {
-          args: [
-            resolve(env.DATA_DIR, "soundxyz-call-tokenuri-transformation"),
-          ],
-        },
-        transformer: {},
-      },
-      {
-        name: "zora-get-tokenuri",
-        extractor: {
-          args: [
-            resolve(env.DATA_DIR, "zora-call-tokenmetadatauri-transformation"),
-          ],
-        },
-        transformer: {},
-      },
-    ],
-    [
-      {
-        name: "music-os-accumulator",
-        extractor: { args: [] },
-        transformer: {},
-      },
-    ],
-  ];
 
   for await (const path of crawlPath) {
     await Promise.all(
@@ -289,4 +224,10 @@ export async function init(worker) {
       })
     );
   }
+
+  log("All strategies executed");
+  worker.postMessage({
+    type: "exit",
+    version: "0.0.1",
+  });
 }

--- a/src/strategies/music-os-accumulator/extractor.mjs
+++ b/src/strategies/music-os-accumulator/extractor.mjs
@@ -161,12 +161,7 @@ export async function init() {
     }
   }
   return {
-    messages: [
-      {
-        type: "exit",
-        version: "0.0.1",
-      },
-    ],
+    messages: [],
     write: JSON.stringify(Array.from(tracks.values())),
   };
 }


### PR DESCRIPTION
In the previous PR #168, I implemented a functionality to define a crawl path for the strategies. In this PR, I take crawl path as an input instead of defining it inside strategies.

This is useful to implement a CLI for neume-core. The idea is to define the crawl path in a file and through CLI give that file as an input.

The work for CLI is done in neume-network/core#68.