### PR TITLE
remove test.skip from call-block-logs test

### DIFF
--- a/test/strategies/call-block-logs/extractor_test.mjs
+++ b/test/strategies/call-block-logs/extractor_test.mjs
@@ -50,10 +50,7 @@ test("if call-block-logs adjusts end block number when start block is in range o
   t.is(messages[0].params[0].fromBlock, "0xeb2206");
 });
 
-// NOTE: Since we now use `init` to first download the network's current block,
-// it seems `snapshotExtractor` isn't capable of waiting a number of messages
-// before return the results.
-test.skip("call-block-logs extractor", async (t) => {
+test("call-block-logs extractor", async (t) => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(


### PR DESCRIPTION
This PR closes #230. I think it is false issue. Snapshot extractor does wait for `update` function. The call-block-logs test is also working after removing `test.skip`.

Here's a pseudocode to explain what happens.

```js
let write = ''
let ret = await init()
write += ret.write
while(msgIn !== msgOut) {
  const ret = await update()
  write += ret.write
}
return write
```

In short, snapshot extractor is a mini lifecycle.
