### PR TITLE
use `util.inspect` instead of `JSON.stringify`

### DIFF
--- a/src/lifecycle.mjs
+++ b/src/lifecycle.mjs
@@ -7,6 +7,7 @@ import { env } from "process";
 import Ajv from "ajv";
 import { workerMessage } from "@neume-network/message-schema";
 import { crawlPath as crawlPathSchema } from "@neume-network/schema";
+import util from "util";
 
 import { NotFoundError } from "./errors.mjs";
 import { fileExists, loadStrategies } from "./disc.mjs";
@@ -259,9 +260,13 @@ export async function init(worker, crawlPath) {
   });
 
   log(
-    `Starting to execute strategies with the following crawlPath ${JSON.stringify(
-      crawlPath
-    )}`
+    `Starting to execute strategies with the following crawlPath`,
+    util.inspect(crawlPath, {
+      depth: null,
+      colors: true,
+      breakLength: "Infinity",
+      compact: true,
+    })
   );
 
   for (const segment of crawlPath) {


### PR DESCRIPTION
A short PR which fixes #257. The [`util.inspect()`](https://nodejs.org/api/util.html#util_util_inspect_object_options) method returns a string representation of object that is intended for debugging.

Sample:
```
neume-network-strategies:lifecycle Starting to execute strategies with the following crawlPath [
  [
    {
      name: 'call-block-logs',
      extractor: { args: [ 15232606, 15280370 ] }
    }
  ],
  [
    {
      name: 'filter-music-nfts',
      extractor: {
        args: [
          '/neume-network/core/data/call-block-logs-extraction',
          {
            '0xabefbc9fd2f806065b4f3c237d4b59d9a97bcac7': { name: 'zora' },
            '0x0bc2a24ce568dad89691116d5b34deb6c203f342': { name: 'catalog', version: '2.0.0' },
            '0xf5819e27b9bad9f97c177bf007c1f96f26d91ca6': { name: 'noizd' },
            '0x2b5426a5b98a3e366230eba9f95a24f09ae4a584': { name: 'mintsongs', version: '2.0.0' }
          }
        ]
      }
    }
  ],
```

For displaying logs in a single line like `JSON.stringify` we can use:
```js
util.inspect(crawlPath, {
    depth: null,
    colors: true,
    breakLength: "Infinity",
    compact: true
})
```