### PR TITLE
compare objects and use `await readFile` in all extractor_test

### DIFF
--- a/test/strategies/call-block-logs/extractor_test.mjs
+++ b/test/strategies/call-block-logs/extractor_test.mjs
@@ -65,5 +65,5 @@ test.skip("call-block-logs extractor", async (t) => {
   snapshot.inputs = content;
 
   const result = await snapshotExtractor(blockLogs, snapshot);
-  t.is(result, snapshot.expect.write);
+  t.deepEqual(JSON.parse(result), JSON.parse(snapshot.expect.write));
 });

--- a/test/strategies/call-block-logs/extractor_test.mjs
+++ b/test/strategies/call-block-logs/extractor_test.mjs
@@ -1,5 +1,5 @@
 // @format
-import fs from "fs";
+import fs from "fs/promises";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { env } from "process";
@@ -57,11 +57,11 @@ test.skip("call-block-logs extractor", async (t) => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   const filePath = resolve(__dirname, snapshot.inputs[0]);
-  const content = JSON.parse(fs.readFileSync(filePath).toString());
+  const content = JSON.parse((await fs.readFile(filePath)).toString());
   snapshot.inputs = content;
 
   const result = await snapshotExtractor(blockLogs, snapshot);

--- a/test/strategies/call-contract-owner/extractor_test.mjs
+++ b/test/strategies/call-contract-owner/extractor_test.mjs
@@ -1,5 +1,5 @@
 // @format
-import fs from "fs";
+import fs from "fs/promises";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -12,7 +12,7 @@ test("call-contract-owner extractor", async (t) => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);

--- a/test/strategies/call-contract-owner/extractor_test.mjs
+++ b/test/strategies/call-contract-owner/extractor_test.mjs
@@ -18,5 +18,5 @@ test("call-contract-owner extractor", async (t) => {
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);
 
   const result = await snapshotExtractor(extractor, snapshot);
-  t.is(result, snapshot.expect.write);
+  t.deepEqual(JSON.parse(result), JSON.parse(snapshot.expect.write));
 });

--- a/test/strategies/soundxyz-call-tokenuri/extractor_test.mjs
+++ b/test/strategies/soundxyz-call-tokenuri/extractor_test.mjs
@@ -1,5 +1,5 @@
 // @format
-import fs from "fs";
+import fs from "fs/promises";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -12,7 +12,7 @@ test("soundxyz-call-tokenuri extractor", async (t) => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);

--- a/test/strategies/soundxyz-call-tokenuri/extractor_test.mjs
+++ b/test/strategies/soundxyz-call-tokenuri/extractor_test.mjs
@@ -18,5 +18,5 @@ test("soundxyz-call-tokenuri extractor", async (t) => {
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);
 
   const result = await snapshotExtractor(extractor, snapshot);
-  t.is(result, snapshot.expect.write);
+  t.deepEqual(JSON.parse(result), JSON.parse(snapshot.expect.write));
 });

--- a/test/strategies/soundxyz-get-tokenuri/extractor_test.mjs
+++ b/test/strategies/soundxyz-get-tokenuri/extractor_test.mjs
@@ -1,5 +1,5 @@
 // @format
-import fs from "fs";
+import fs from "fs/promises";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import test from "ava";
@@ -11,7 +11,7 @@ test("soundxyz-get-tokenuri extractor", async (t) => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);
@@ -24,7 +24,7 @@ test("if soundxyz-get-tokenuri can gracefully shut down if no data is available 
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   snapshot.inputs[0] = "non-existent-file";

--- a/test/strategies/soundxyz-get-tokenuri/extractor_test.mjs
+++ b/test/strategies/soundxyz-get-tokenuri/extractor_test.mjs
@@ -17,7 +17,7 @@ test("soundxyz-get-tokenuri extractor", async (t) => {
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);
 
   const result = await snapshotExtractor(soundxyz, snapshot);
-  t.is(result, snapshot.expect.write);
+  t.deepEqual(JSON.parse(result), JSON.parse(snapshot.expect.write));
 });
 
 test("if soundxyz-get-tokenuri can gracefully shut down if no data is available to process", async (t) => {

--- a/test/strategies/soundxyz-metadata/extractor_test.mjs
+++ b/test/strategies/soundxyz-metadata/extractor_test.mjs
@@ -1,5 +1,5 @@
 // @format
-import fs from "fs";
+import fs from "fs/promises";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -12,7 +12,7 @@ test("soundxyz-metadata extractor", async (t) => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);

--- a/test/strategies/soundxyz-metadata/extractor_test.mjs
+++ b/test/strategies/soundxyz-metadata/extractor_test.mjs
@@ -18,5 +18,5 @@ test("soundxyz-metadata extractor", async (t) => {
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);
 
   const result = await snapshotExtractor(extractor, snapshot);
-  t.is(result, snapshot.expect.write);
+  t.deepEqual(JSON.parse(result), JSON.parse(snapshot.expect.write));
 });

--- a/test/strategies/zora-call-tokenmetadatauri/extractor_test.mjs
+++ b/test/strategies/zora-call-tokenmetadatauri/extractor_test.mjs
@@ -18,5 +18,5 @@ test("zora-call-tokenmetadatauri extractor", async (t) => {
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);
 
   const result = await snapshotExtractor(zora, snapshot);
-  t.is(result, snapshot.expect.write);
+  t.deepEqual(JSON.parse(result), JSON.parse(snapshot.expect.write));
 });

--- a/test/strategies/zora-call-tokenmetadatauri/extractor_test.mjs
+++ b/test/strategies/zora-call-tokenmetadatauri/extractor_test.mjs
@@ -1,5 +1,5 @@
 // @format
-import fs from "fs";
+import fs from "fs/promises";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -12,7 +12,7 @@ test("zora-call-tokenmetadatauri extractor", async (t) => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);

--- a/test/strategies/zora-call-tokenuri/extractor_test.mjs
+++ b/test/strategies/zora-call-tokenuri/extractor_test.mjs
@@ -18,5 +18,5 @@ test("zora-call-tokenuri extractor", async (t) => {
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);
 
   const result = await snapshotExtractor(zora, snapshot);
-  t.is(result, snapshot.expect.write);
+  t.deepEqual(JSON.parse(result), JSON.parse(snapshot.expect.write));
 });

--- a/test/strategies/zora-call-tokenuri/extractor_test.mjs
+++ b/test/strategies/zora-call-tokenuri/extractor_test.mjs
@@ -1,5 +1,5 @@
 // @format
-import fs from "fs";
+import fs from "fs/promises";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -12,7 +12,7 @@ test("zora-call-tokenuri extractor", async (t) => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);

--- a/test/strategies/zora-get-tokenuri/extractor_test.mjs
+++ b/test/strategies/zora-get-tokenuri/extractor_test.mjs
@@ -1,6 +1,5 @@
 // @format
-import { env } from "process";
-import fs from "fs";
+import fs from "fs/promises";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import test from "ava";
@@ -12,7 +11,7 @@ test("zora-get-tokenuri extractor", async (t) => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   snapshot.inputs[0] = resolve(__dirname, snapshot.inputs[0]);
@@ -37,7 +36,7 @@ test("if zora-get-tokenuri can gracefully shutdown if no call-tokenuri file is p
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
   const snapshot = JSON.parse(
-    fs.readFileSync(resolve(__dirname, "./extractor_snapshot.json"))
+    await fs.readFile(resolve(__dirname, "./extractor_snapshot.json"))
   );
 
   snapshot.inputs[0] = "non-existent";


### PR DESCRIPTION
This PR contains two commits. One fixes #91 and the other replaces all `readFileSync` with `readFile`. We don't have an issue for the second but since I was already doing changes in test files I thought to do this too.