### PR TITLE
add schema validation for call-block-logs and zora

### DIFF
--- a/src/lifecycle.mjs
+++ b/src/lifecycle.mjs
@@ -5,6 +5,7 @@ import { createReadStream, appendFileSync } from "fs";
 import EventEmitter, { once } from "events";
 import { env } from "process";
 import Ajv from "ajv";
+import addFormats from "ajv-formats";
 import { workerMessage } from "@neume-network/message-schema";
 import { crawlPath as crawlPathSchema } from "@neume-network/schema";
 import util from "util";
@@ -28,6 +29,7 @@ const fileNames = {
   extractor: "extractor.mjs",
 };
 const ajv = new Ajv();
+addFormats(ajv);
 const workerValidator = ajv.compile(workerMessage);
 const crawlPathValidator = ajv.compile(crawlPathSchema);
 

--- a/src/lifecycle.mjs
+++ b/src/lifecycle.mjs
@@ -177,11 +177,11 @@ export function extract(strategy, worker, messageRouter, args = []) {
         );
       } else {
         let valid = true;
-        const validator = ajv.compile(message.schema);
+        let validator;
         if (message.schema) {
+          validator = ajv.compile(message.schema);
           valid = validator(message.results);
         }
-
         if (valid) {
           const result = await strategy.module.update(message);
           if (!result) {

--- a/src/strategies/call-block-logs/extractor.mjs
+++ b/src/strategies/call-block-logs/extractor.mjs
@@ -1,10 +1,12 @@
 //@format
 import { env } from "process";
+import { readFile } from "fs/promises";
 import assert from "assert";
 
 import { toHex } from "eth-fun";
 
 import logger from "../../logger.mjs";
+import { eth_blockNumberSchema, eth_getLogsSchema } from "./schemas.mjs";
 
 const version = "0.0.1";
 export const name = "call-block-logs";
@@ -32,6 +34,7 @@ function blockNumber(start, end) {
     version,
     options,
     results: null,
+    schema: eth_blockNumberSchema,
     error: null,
   };
 }
@@ -50,6 +53,7 @@ function callBlockLogs(number) {
     version,
     options,
     results: null,
+    schema: eth_getLogsSchema,
     error: null,
   };
 }

--- a/src/strategies/call-block-logs/schemas.mjs
+++ b/src/strategies/call-block-logs/schemas.mjs
@@ -1,0 +1,63 @@
+export const eth_blockNumberSchema = {
+  type: "string",
+  pattern: "^0x[a-fA-F0-9]+$",
+};
+
+export const eth_getLogsSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  definitions: {
+    Log: {
+      additionalProperties: {},
+      description: "An indexed event generated during a transaction",
+      properties: {
+        address: {
+          description: "Sender of the transaction",
+          type: "string",
+        },
+        blockHash: {
+          description:
+            "The hex representation of the Keccak 256 of the RLP encoded block",
+          type: "string",
+        },
+        blockNumber: {
+          description: "The hex representation of the block's height",
+          type: "string",
+        },
+        data: {
+          description: "The data/input string sent along with the transaction",
+          type: "string",
+        },
+        logIndex: {
+          description:
+            "The index of the event within its transaction, null when its pending",
+          type: "string",
+        },
+        removed: {
+          description: "Whether or not the log was orphaned off the main chain",
+          type: "boolean",
+        },
+        topics: {
+          description:
+            "Topics are order-dependent. Each topic can also be an array of DATA with 'or' options.",
+          items: {
+            type: "string",
+          },
+          type: "array",
+        },
+        transactionHash: {
+          description: "Keccak 256 Hash of the RLP encoding of a transaction",
+          type: "string",
+        },
+        transactionIndex: {
+          description: "The index of the transaction. null when its pending",
+          type: "string",
+        },
+      },
+      type: "object",
+    },
+  },
+  items: {
+    $ref: "#/definitions/Log",
+  },
+  type: "array",
+};

--- a/src/strategies/zora-get-tokenuri/extractor.mjs
+++ b/src/strategies/zora-get-tokenuri/extractor.mjs
@@ -1,8 +1,14 @@
 // @format
 import { getIpfsTokenUriFactory } from "../../strategy-factories/get-ipfs-tokenuri/extractor.mjs";
+import { zoraTokenUriSchema } from "./schemas.mjs";
 
 export const version = "0.0.1";
 export const name = "zora-get-tokenuri";
-export const props = { strategyName: name, version, options: {} };
+export const props = {
+  strategyName: name,
+  version,
+  options: {},
+  schema: zoraTokenUriSchema,
+};
 
 export const { init, update } = getIpfsTokenUriFactory(props);

--- a/src/strategies/zora-get-tokenuri/schemas.mjs
+++ b/src/strategies/zora-get-tokenuri/schemas.mjs
@@ -1,0 +1,44 @@
+export const zoraTokenUriSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  properties: {
+    body: {
+      properties: {
+        artist: {
+          type: "string",
+        },
+        artwork: {
+          properties: {
+            info: {
+              properties: {
+                uri: {
+                  format: "uri",
+                  type: "string",
+                },
+              },
+              required: ["uri"],
+              type: "object",
+            },
+          },
+          type: "object",
+        },
+        duration: {
+          format: "float",
+          type: "number",
+        },
+        notes: {
+          type: "string",
+          nullable: true,
+        },
+        title: {
+          type: "string",
+        },
+      },
+      required: ["artist", "title"],
+      type: "object",
+    },
+    name: {
+      type: "string",
+    },
+  },
+  type: "object",
+};

--- a/src/strategy-factories/call-tokenuri/extractor.mjs
+++ b/src/strategy-factories/call-tokenuri/extractor.mjs
@@ -7,6 +7,7 @@ import { toHex, encodeFunctionCall } from "eth-fun";
 
 import logger from "../../logger.mjs";
 import { fileExists } from "../../disc.mjs";
+import { eth_callSchema } from "./schema.mjs";
 
 // Instead of querying at the block number soundxyz NFT
 // was minted, we query at a higher block number because
@@ -95,6 +96,7 @@ export const callTokenUriFactory = (props) => {
         tokenId,
       },
       results: null,
+      schema: eth_callSchema,
       error: null,
     };
   }

--- a/src/strategy-factories/call-tokenuri/schema.mjs
+++ b/src/strategy-factories/call-tokenuri/schema.mjs
@@ -1,0 +1,5 @@
+export const eth_callSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  description: "Hex representation of a variable length byte array",
+  type: "string",
+};

--- a/src/strategy-factories/get-ipfs-tokenuri/extractor.mjs
+++ b/src/strategy-factories/get-ipfs-tokenuri/extractor.mjs
@@ -7,7 +7,7 @@ import logger from "../../logger.mjs";
 import { fileExists } from "../../disc.mjs";
 
 export const getIpfsTokenUriFactory = (props) => {
-  const { strategyName, options, version } = props;
+  const { strategyName, options, version, schema } = props;
   const log = logger(strategyName);
 
   if (env.IPFS_HTTPS_GATEWAY_KEY) {
@@ -69,6 +69,7 @@ export const getIpfsTokenUriFactory = (props) => {
         headers: options.headers,
       },
       results: null,
+      schema,
       error: null,
     };
   };

--- a/utils/snapshot_extractor.mjs
+++ b/utils/snapshot_extractor.mjs
@@ -3,9 +3,13 @@ import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { once } from "events";
 import { Worker } from "worker_threads";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
 import { prepareMessages } from "../src/lifecycle.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const ajv = new Ajv();
+addFormats(ajv);
 
 export default async function snapshotExtractor(extractor, { inputs }) {
   const worker = new Worker(resolve(__dirname, "./worker_start.mjs"), {
@@ -36,14 +40,25 @@ export default async function snapshotExtractor(extractor, { inputs }) {
       throw new Error(message.error);
     }
 
-    const ret = extractor.update(message);
-    if (ret.write) write(ret.write);
+    let valid = true;
+    let validator;
+    if (message.schema) {
+      validator = ajv.compile(message.schema);
+      valid = validator(message.results);
+    }
 
-    prepareMessages(ret.messages, extractor.name)
-      .filter(({ type }) => type !== "extraction" && type !== "transformation")
-      .forEach((message) => {
-        postMessage(message);
-      });
+    if (valid) {
+      const ret = extractor.update(message);
+      if (ret.write) write(ret.write);
+
+      prepareMessages(ret.messages, extractor.name)
+        .filter(
+          ({ type }) => type !== "extraction" && type !== "transformation"
+        )
+        .forEach((message) => {
+          postMessage(message);
+        });
+    }
 
     numberOfPostedMessages--;
     if (numberOfPostedMessages === 0) {


### PR DESCRIPTION
This PR validates schema for call-block-logs, zora-call-tokenuri, zora-call-tokenmetadatauri, and zora-get-tokenuri. If a `schema` property is provided in message then the `result` is validated against the provided `schema`. In case the schema isn't valid the message gets logged and ignored by the lifecycle.

For json-rpc calls the schema has been taken from [ethereum-json-rpc-specification](https://github.com/etclabscore/ethereum-json-rpc-specification/). For zora-get-tokenuri I have created the schema by looking at the response and tested it against the existing data of music-os-accumulator. 

The schema for zora-get-tokenuri is not strict i.e. it can have new fields not mentioned in the schema and there won't be an error. The schema mainly checks if a property is present then it should be of correct type. For example, `body.artwork.info` is not required but if it is present then it should contain a `uri` field with a valid URI.

I wanted to test schemas in the wild before adding them to all the strategies. Hence, this PR excludes sound.

Note to self:
- [ ] Add `schema` property to message neume-network/schema